### PR TITLE
feat 仮のログイン画面配置/管理画面

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4,6 +4,9 @@ import { RegisterPage } from "./pages/RegisterPage";
 import { CheckoutPage } from "./pages/CheckoutPage";
 import { SuccessPage } from "./pages/SuccessPage";
 import { QueuePage } from "./pages/QueuePage";
+import { LoginPage } from "./pages/LoginPage";
+import { DashboardPage } from "./pages/admin/DashboardPage";
+import { ProductManagementPage } from "./pages/admin/ProductManagementPage";
 
 function App() {
   const [message, setMessage] = useState("");
@@ -24,9 +27,12 @@ function App() {
           <strong>API Response:</strong> {message || "Loading..."}
         </div>
         
-        {/* ナビゲーション */}
+        {/* ナビゲーション（モック確認用） */}
         <div style={{ padding: '10px', backgroundColor: '#f0f0f0', marginBottom: '20px' }}>
           <nav style={{ display: 'flex', gap: '15px' }}>
+            <Link to="/login">ログイン画面</Link>
+            <Link to="/admin">ダッシュボード(管理)</Link>
+            <span style={{ color: '#ccc' }}>|</span>
             <Link to="/">レジ画面(ホーム)</Link>
             <Link to="/checkout">会計画面</Link>
             <Link to="/queue">引換待機列</Link>
@@ -35,6 +41,9 @@ function App() {
 
         {/* 画面ルーティング */}
         <Routes>
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/admin" element={<DashboardPage />} />
+          <Route path="/admin/products" element={<ProductManagementPage />} />
           <Route path="/" element={<RegisterPage />} />
           <Route path="/checkout" element={<CheckoutPage />} />
           <Route path="/queue" element={<QueuePage />} />

--- a/apps/web/src/pages/LoginPage.tsx
+++ b/apps/web/src/pages/LoginPage.tsx
@@ -1,0 +1,38 @@
+import { Link } from 'react-router-dom';
+
+export const LoginPage = () => {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', minHeight: '80vh', padding: '20px' }}>
+      <div style={{ width: '100%', maxWidth: '400px', background: 'white', padding: '40px', borderRadius: '12px', boxShadow: '0 4px 12px rgba(0,0,0,0.1)' }}>
+        <h1 style={{ textAlign: 'center', marginBottom: '30px', color: '#1a73e8' }}>Rejogi ログイン</h1>
+        
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '15px', marginBottom: '30px' }}>
+          <div>
+            <label style={{ display: 'block', marginBottom: '5px', fontWeight: 'bold' }}>ユーザーID / Email</label>
+            <input type="text" placeholder="user@example.com" style={{ width: '100%', padding: '12px', borderRadius: '6px', border: '1px solid #ccc', boxSizing: 'border-box' }} />
+          </div>
+          <div>
+            <label style={{ display: 'block', marginBottom: '5px', fontWeight: 'bold' }}>パスワード</label>
+            <input type="password" placeholder="••••••••" style={{ width: '100%', padding: '12px', borderRadius: '6px', border: '1px solid #ccc', boxSizing: 'border-box' }} />
+          </div>
+        </div>
+
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+          {/* 今回はモックなので、リンクで強制的に画面遷移させます */}
+          <Link 
+            to="/admin" 
+            style={{ display: 'block', padding: '15px', background: '#34a853', color: 'white', textAlign: 'center', borderRadius: '6px', textDecoration: 'none', fontWeight: 'bold' }}
+          >
+            管理者としてログイン
+          </Link>
+          <Link 
+            to="/" 
+            style={{ display: 'block', padding: '15px', background: '#1a73e8', color: 'white', textAlign: 'center', borderRadius: '6px', textDecoration: 'none', fontWeight: 'bold' }}
+          >
+            一般スタッフとしてログイン (レジへ)
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/pages/admin/DashboardPage.tsx
+++ b/apps/web/src/pages/admin/DashboardPage.tsx
@@ -75,6 +75,9 @@ export const DashboardPage = () => {
         {/* 売上まとめ */}
         <Link 
           to={hasActiveSession ? "/admin/sales" : "#"}
+          aria-disabled={!hasActiveSession}
+          tabIndex={!hasActiveSession ? -1 : undefined}
+          onClick={!hasActiveSession ? (e) => e.preventDefault() : undefined}
           style={{
             display: 'block',
             padding: '30px',
@@ -95,6 +98,9 @@ export const DashboardPage = () => {
         {/* メンバー管理 */}
         <Link 
           to={hasActiveSession ? "/admin/members" : "#"}
+          aria-disabled={!hasActiveSession}
+          tabIndex={!hasActiveSession ? -1 : undefined}
+          onClick={!hasActiveSession ? (e) => e.preventDefault() : undefined}
           style={{
             display: 'block',
             padding: '30px',

--- a/apps/web/src/pages/admin/DashboardPage.tsx
+++ b/apps/web/src/pages/admin/DashboardPage.tsx
@@ -1,0 +1,136 @@
+import { Link, useNavigate } from 'react-router-dom';
+import { useState, useEffect } from 'react';
+
+// ダミーデータ：今年度のセッションが作成されているかどうかの状態
+// false にすると各管理機能がグレーアウトされます
+const DUMMY_HAS_ACTIVE_SESSION = true;
+
+// 認証トークンのダミーチェック用 (将来的にはこの判定を Context や API 呼び出しに置き換えます)
+const IS_AUTHENTICATED_MOCK = true; // false にするとログイン画面へリダイレクトされます
+
+export const DashboardPage = () => {
+  const navigate = useNavigate();
+  const [hasActiveSession, setHasActiveSession] = useState(DUMMY_HAS_ACTIVE_SESSION);
+
+  useEffect(() => {
+    // 【将来の実装想定】ここでlocalStorageのトークン確認や、APIでの権限チェックを行う
+    // const token = localStorage.getItem('auth_token');
+    // if (!token) { navigate('/login'); }
+    
+    if (!IS_AUTHENTICATED_MOCK) {
+      alert('権限がありません。ログインしてください。');
+      navigate('/login');
+    }
+  }, [navigate]);
+
+  return (
+    <div style={{ padding: '20px', maxWidth: '800px', margin: '0 auto' }}>
+      <header style={{ display: 'flex', flexDirection: 'column', gap: '15px', borderBottom: '2px solid #333', paddingBottom: '15px', marginBottom: '30px' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: '10px' }}>
+          <h1 style={{ margin: 0, fontSize: '2em' }}>ダッシュボード（管理用）</h1>
+          <div>
+            <span style={{ marginRight: '15px', color: '#666' }}>ログイン中: 管理者</span>
+            <Link to="/" style={{ color: '#1a73e8', textDecoration: 'none', fontWeight: 'bold' }}>レジ画面へ移動 &rarr;</Link>
+          </div>
+        </div>
+      </header>
+
+      {/* セッション状態のトグル（モック確認用） */}
+      <div style={{ marginBottom: '30px', padding: '15px', background: '#fff3cd', borderRadius: '8px', display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <div>
+          <strong style={{ display: 'block', marginBottom: '5px' }}>今年度のセッション（屋台・イベント）</strong>
+          <span style={{ color: hasActiveSession ? '#137333' : '#b31412', fontWeight: 'bold' }}>
+            {hasActiveSession ? '✓ 作成済み（各種操作が可能です）' : '未作成（先にセッションを作成してください）'}
+          </span>
+        </div>
+        <button 
+          onClick={() => setHasActiveSession(!hasActiveSession)}
+          style={{ padding: '8px 16px', borderRadius: '4px', border: '1px solid #ccc', cursor: 'pointer' }}
+        >
+          状態を切り替える(テスト用)
+        </button>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(300px, 1fr))', gap: '20px' }}>
+        
+        {/* 商品・セッション管理 */}
+        <Link 
+          to="/admin/products"
+          style={{
+            display: 'block',
+            padding: '30px',
+            background: 'white',
+            borderRadius: '12px',
+            textDecoration: 'none',
+            color: '#333',
+            border: '1px solid #eee',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
+            transition: 'transform 0.2s, box-shadow 0.2s',
+          }}
+        >
+          <h2 style={{ margin: '0 0 10px 0', color: '#1a73e8' }}>📦 商品・セッション管理</h2>
+          <p style={{ margin: 0, color: '#666', lineHeight: 1.5 }}>年度や屋台名の設定、販売する商品や割引券の登録・編集を行います。</p>
+        </Link>
+
+        {/* 売上まとめ */}
+        <Link 
+          to={hasActiveSession ? "/admin/sales" : "#"}
+          style={{
+            display: 'block',
+            padding: '30px',
+            background: hasActiveSession ? 'white' : '#f5f5f5',
+            borderRadius: '12px',
+            textDecoration: 'none',
+            color: hasActiveSession ? '#333' : '#999',
+            border: '1px solid #eee',
+            boxShadow: hasActiveSession ? '0 2px 8px rgba(0,0,0,0.05)' : 'none',
+            opacity: hasActiveSession ? 1 : 0.6,
+            pointerEvents: hasActiveSession ? 'auto' : 'none'
+          }}
+        >
+          <h2 style={{ margin: '0 0 10px 0', color: hasActiveSession ? '#34a853' : '#999' }}>📈 売上まとめ</h2>
+          <p style={{ margin: 0, color: hasActiveSession ? '#666' : '#999', lineHeight: 1.5 }}>現在の総売上、販売個数などの集計データを確認します。</p>
+        </Link>
+
+        {/* メンバー管理 */}
+        <Link 
+          to={hasActiveSession ? "/admin/members" : "#"}
+          style={{
+            display: 'block',
+            padding: '30px',
+            background: hasActiveSession ? 'white' : '#f5f5f5',
+            borderRadius: '12px',
+            textDecoration: 'none',
+            color: hasActiveSession ? '#333' : '#999',
+            border: '1px solid #eee',
+            boxShadow: hasActiveSession ? '0 2px 8px rgba(0,0,0,0.05)' : 'none',
+            opacity: hasActiveSession ? 1 : 0.6,
+            pointerEvents: hasActiveSession ? 'auto' : 'none'
+          }}
+        >
+          <h2 style={{ margin: '0 0 10px 0', color: hasActiveSession ? '#fbbc04' : '#999' }}>👥 メンバー管理</h2>
+          <p style={{ margin: 0, color: hasActiveSession ? '#666' : '#999', lineHeight: 1.5 }}>現在ログインしているスタッフの確認や権限の管理を行います。</p>
+        </Link>
+
+        {/* 履歴 */}
+        <Link 
+          to="/admin/history"
+          style={{
+            display: 'block',
+            padding: '30px',
+            background: 'white',
+            borderRadius: '12px',
+            textDecoration: 'none',
+            color: '#333',
+            border: '1px solid #eee',
+            boxShadow: '0 2px 8px rgba(0,0,0,0.05)',
+          }}
+        >
+          <h2 style={{ margin: '0 0 10px 0', color: '#ea4335' }}>🕰️ 履歴・過去データ</h2>
+          <p style={{ margin: 0, color: '#666', lineHeight: 1.5 }}>過去の年度・セッションごとの取引詳細や履歴を閲覧します。</p>
+        </Link>
+
+      </div>
+    </div>
+  );
+};

--- a/apps/web/src/pages/admin/ProductManagementPage.tsx
+++ b/apps/web/src/pages/admin/ProductManagementPage.tsx
@@ -21,8 +21,9 @@ export const ProductManagementPage = () => {
       <div style={{ background: '#f8f9fa', padding: '20px', borderRadius: '12px', marginBottom: '30px' }}>
         <h2 style={{ fontSize: '1.2em', marginTop: 0 }}>セッション情報設定</h2>
         <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
-          <label style={{ fontWeight: 'bold' }}>イベント・屋台名</label>
+          <label htmlFor="sessionName" style={{ fontWeight: 'bold' }}>イベント・屋台名</label>
           <input 
+            id="sessionName"
             type="text" 
             value={sessionName} 
             onChange={(e) => setSessionName(e.target.value)}

--- a/apps/web/src/pages/admin/ProductManagementPage.tsx
+++ b/apps/web/src/pages/admin/ProductManagementPage.tsx
@@ -1,0 +1,69 @@
+import { Link } from 'react-router-dom';
+import { useState } from 'react';
+
+// ダミーの商品データ
+const initialProducts = [
+  { id: '1', name: '焼きそば', price: 500 },
+  { id: '2', name: 'たこ焼き', price: 400 },
+];
+
+export const ProductManagementPage = () => {
+  const [products] = useState(initialProducts); // SetProductsを未使用のため除去
+  const [sessionName, setSessionName] = useState('2026年 学園祭 焼きそば屋台');
+
+  return (
+    <div style={{ padding: '20px', maxWidth: '800px', margin: '0 auto' }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', borderBottom: '2px solid #333', paddingBottom: '10px', marginBottom: '30px' }}>
+        <h1 style={{ margin: 0 }}>商品・セッション管理</h1>
+        <Link to="/admin" style={{ color: '#666', textDecoration: 'none' }}>&lt; ダッシュボードに戻る</Link>
+      </div>
+
+      <div style={{ background: '#f8f9fa', padding: '20px', borderRadius: '12px', marginBottom: '30px' }}>
+        <h2 style={{ fontSize: '1.2em', marginTop: 0 }}>セッション情報設定</h2>
+        <div style={{ display: 'flex', flexDirection: 'column', gap: '10px' }}>
+          <label style={{ fontWeight: 'bold' }}>イベント・屋台名</label>
+          <input 
+            type="text" 
+            value={sessionName} 
+            onChange={(e) => setSessionName(e.target.value)}
+            style={{ padding: '10px', fontSize: '1.1em', borderRadius: '4px', border: '1px solid #ccc' }}
+          />
+          <button style={{ padding: '10px 20px', background: '#1a73e8', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer', alignSelf: 'flex-start', marginTop: '10px' }}>
+            設定を保存
+          </button>
+        </div>
+      </div>
+
+      <div>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: '15px' }}>
+          <h2 style={{ fontSize: '1.2em', margin: 0 }}>販売商品・割引券 登録</h2>
+          <button style={{ padding: '8px 16px', background: '#34a853', color: 'white', border: 'none', borderRadius: '4px', cursor: 'pointer', fontWeight: 'bold' }}>
+            + 新規追加
+          </button>
+        </div>
+
+        <table style={{ width: '100%', borderCollapse: 'collapse', background: 'white', borderRadius: '8px', overflow: 'hidden', boxShadow: '0 1px 4px rgba(0,0,0,0.1)' }}>
+          <thead style={{ background: '#f1f3f4' }}>
+            <tr>
+              <th style={{ padding: '12px', textAlign: 'left', borderBottom: '2px solid #ddd' }}>商品名</th>
+              <th style={{ padding: '12px', textAlign: 'left', borderBottom: '2px solid #ddd' }}>価格</th>
+              <th style={{ padding: '12px', textAlign: 'center', borderBottom: '2px solid #ddd' }}>操作</th>
+            </tr>
+          </thead>
+          <tbody>
+            {products.map(p => (
+              <tr key={p.id} style={{ borderBottom: '1px solid #eee' }}>
+                <td style={{ padding: '12px' }}>{p.name}</td>
+                <td style={{ padding: '12px' }}>¥{p.price}</td>
+                <td style={{ padding: '12px', textAlign: 'center' }}>
+                  <button style={{ padding: '6px 12px', margin: '0 4px', border: '1px solid #ccc', background: 'white', borderRadius: '4px' }}>編集</button>
+                  <button style={{ padding: '6px 12px', margin: '0 4px', border: '1px solid #dc3545', color: '#dc3545', background: 'white', borderRadius: '4px' }}>削除</button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## 概要

管理画面関連のUI作成
仮のアクセス制限機能　その他文字修正

## 変更内容

- ログイン、ダッシュボード仮作成
- 文字被りレスポンシブ修正
- 

## 確認方法

- npm run dev
- DashboardPage.tsxの中のIS_AUTHENTICATED_MOCK 値を変えると管理画面に行けない状態に

## チェックリスト

- [x] 動作確認した
- [x] lint通した
- [ ] 不要なconsole.log削除した


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ナビゲーションにログイン・管理者ダッシュボード・商品管理へのリンクと視覚的区切りを追加しました。
  * ログインページを追加（ID/メール・パス入力欄、管理者／一般スタッフへの遷移リンクを表示）。
  * 管理者ダッシュボードを追加（セッション作成状況の表示、セッション状態に応じたメニューの有効/無効表示）。
  * 商品管理ページを追加（セッション名の入力欄、販売商品の一覧表示、編集/削除ボタン、＋新規追加ボタンを表示）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->